### PR TITLE
Improve admin key handling and reward thumbnails

### DIFF
--- a/server/public/admin.html
+++ b/server/public/admin.html
@@ -5,8 +5,8 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>CryptoKids — Admin</title>
-  <link rel="icon" href="data:,">
-  <link rel="manifest" href="/manifest.webmanifest?v=__BUILD__">
+  <!-- <link rel="icon" href="/favicon.ico"> -->
+  <!-- <link rel="manifest" href="/manifest.webmanifest?v=__BUILD__"> -->
   <meta name="theme-color" content="#ffffff">
   <style>
     :root {
@@ -391,7 +391,7 @@
       <div class="admin-key">
         <label>
           Admin Key
-          <input id="adminKey" type="text" placeholder="enter admin key">
+          <input id="adminKey" type="text" placeholder="enter admin key (Mamapapa)">
         </label>
         <button id="saveAdminKey">Save</button>
       </div>
@@ -633,6 +633,6 @@
 
   <script src="/qrcode.min.js?v=__BUILD__"></script>
   <script src="https://unpkg.com/jsqr"></script>
-  <script src="/admin.js?v=__BUILD__"></script>
+  <script defer src="admin.js?v={{shortCommit}}"></script>
 </body>
 </html>

--- a/server/public/admin.js
+++ b/server/public/admin.js
@@ -2,7 +2,16 @@
   if (window.__CK_ADMIN_READY__) return;
   window.__CK_ADMIN_READY__ = true;
 
-  const $ = (id) => document.getElementById(id);
+  const ADMIN_KEY_DEFAULT = 'Mamapapa';
+  const $k = (id) => document.getElementById(id);
+  const $ = $k;
+  const keyInput = $k('adminKey'); // use current ID
+  if (keyInput) {
+    keyInput.placeholder = `enter admin key (${ADMIN_KEY_DEFAULT})`;
+    const saved = localStorage.getItem('CK_ADMIN_KEY');
+    if (!saved) keyInput.value = ADMIN_KEY_DEFAULT;
+  }
+
   const toastHost = $('toastHost');
 
   function toast(msg, type = 'success', ms = 2400) {
@@ -18,33 +27,38 @@
     }, ms);
   }
 
-  const ADMIN_KEY_STORAGE = 'ck_admin_key';
+  const ADMIN_KEY_STORAGE = 'CK_ADMIN_KEY';
   function loadAdminKey() {
     return localStorage.getItem(ADMIN_KEY_STORAGE) || '';
   }
   function saveAdminKey(value) {
     localStorage.setItem(ADMIN_KEY_STORAGE, value || '');
   }
-  function getAdminKey() {
-    return $('adminKey')?.value?.trim() || loadAdminKey();
-  }
 
   $('saveAdminKey')?.addEventListener('click', () => {
-    const value = $('adminKey').value.trim();
+    const value = (keyInput?.value || '').trim();
     saveAdminKey(value);
     toast('Admin key saved');
   });
 
   document.addEventListener('DOMContentLoaded', () => {
     const saved = loadAdminKey();
-    if (saved && $('adminKey')) $('adminKey').value = saved;
+    if (saved && keyInput) keyInput.value = saved;
   });
 
-  function adminFetch(path, init = {}) {
-    const headers = new Headers(init.headers || {});
-    const key = getAdminKey();
-    if (key) headers.set('x-admin-key', key);
-    return fetch(path, { ...init, headers });
+  async function adminFetch(url, opts = {}) {
+    const key = (localStorage.getItem('CK_ADMIN_KEY') || $k('adminKey')?.value || '').trim();
+    const headers = { ...(opts.headers || {}), 'x-admin-key': key };
+    const res = await fetch(url, { ...opts, headers });
+
+    const ctype = res.headers.get('content-type') || '';
+    let body;
+    if (ctype.includes('application/json')) {
+      body = await res.json().catch(() => ({}));
+    } else {
+      body = await res.text().catch(() => '');
+    }
+    return { res, body };
   }
 
   function renderQr(elId, text) {
@@ -85,16 +99,19 @@
     }
     $('issueStatus').textContent = 'Generating QR...';
     try {
-      const res = await adminFetch('/api/tokens/give', {
+      const { res, body } = await adminFetch('/api/tokens/give', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ userId, amount, note: note || undefined })
       });
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.error || 'request failed');
+      const data = body && typeof body === 'object' ? body : {};
+      if (!res.ok) {
+        const msg = (body && body.error) || (typeof body === 'string' ? body : 'request failed');
+        throw new Error(msg);
+      }
       renderQr('qrIssue', data.qrText);
       $('issueLink').value = data.qrText || '';
-      $('issueStatus').textContent = `QR expires in 2 minutes. Amount ${data.amount} points.`;
+      $('issueStatus').textContent = `QR expires in 2 minutes. Amount ${data.amount ?? '?'} points.`;
       toast('QR ready');
     } catch (err) {
       console.error(err);
@@ -131,9 +148,12 @@
     $('holdsStatus').textContent = 'Loading...';
     holdsTable.innerHTML = '';
     try {
-      const res = await adminFetch(`/api/holds?status=${encodeURIComponent(status)}`);
-      const rows = await res.json();
-      if (!res.ok) throw new Error(rows.error || 'failed');
+      const { res, body } = await adminFetch(`/api/holds?status=${encodeURIComponent(status)}`);
+      if (!res.ok) {
+        const msg = (body && body.error) || (typeof body === 'string' ? body : 'failed');
+        throw new Error(msg);
+      }
+      const rows = Array.isArray(body) ? body : [];
       if (!rows.length) {
         holdsTable.innerHTML = '<tr><td colspan="6" class="muted">No holds</td></tr>';
         $('holdsStatus').textContent = '';
@@ -176,10 +196,10 @@
   async function cancelHold(id) {
     if (!confirm('Cancel this hold?')) return;
     try {
-      const res = await adminFetch(`/api/holds/${id}/cancel`, { method: 'POST' });
+      const { res, body } = await adminFetch(`/api/holds/${id}/cancel`, { method: 'POST' });
       if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(data.error || 'failed');
+        const msg = (body && body.error) || (typeof body === 'string' ? body : 'failed');
+        throw new Error(msg);
       }
       toast('Hold canceled');
       loadHolds();
@@ -267,7 +287,6 @@
   }
 
 // Hold scanner — APPROVE spend token
-// Hold scanner — APPROVE spend token
 setupScanner({
   buttonId: 'btnHoldCamera',
   videoId: 'holdVideo',
@@ -288,7 +307,7 @@ setupScanner({
 
     const override = $('holdOverride').value;
     try {
-      const res = await adminFetch(`/api/holds/${holdId}/approve`, {
+      const { res, body } = await adminFetch(`/api/holds/${holdId}/approve`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -297,58 +316,52 @@ setupScanner({
         })
       });
 
-      const isJson = res.headers.get('content-type')?.includes('application/json');
-      const data = isJson ? await res.json() : { error: await res.text() };
-      if (!res.ok) throw new Error(data.error || 'Approve failed');
+      if (!res.ok) {
+        const msg = (body && body.error) || (typeof body === 'string' ? body : 'Approve failed');
+        throw new Error(msg);
+      }
 
+      const data = body && typeof body === 'object' ? body : {};
       toast(`Redeemed ${data.finalCost ?? '??'} points`);
       $('holdOverride').value = '';
       loadHolds();
     } catch (err) {
       toast(err.message || 'Redeem failed', 'error');
     }
-  },   // ← IMPORTANT: comma ends the onToken property
-});     // ← IMPORTANT: closes setupScanner(...) call
+  },  // ← keep this comma
+});   // ← and this closer
 
-
-      const isJson = res.headers.get('content-type')?.includes('application/json');
-      const data = isJson ? await res.json() : { error: await res.text() };
-      if (!res.ok) throw new Error(data.error || 'Approve failed');
-
-      toast(`Redeemed ${data.finalCost ?? '??'} points`);
-      $('holdOverride').value = '';
-      loadHolds();
+// Earn scanner — GENERATE earn/give token
+setupScanner({
+  buttonId: 'btnEarnCamera',
+  videoId: 'earnVideo',
+  canvasId: 'earnCanvas',
+  statusId: 'earnScanStatus',
+  onToken: async (raw) => {
+    const parsed = parseTokenFromScan(raw);
+    if (!parsed || !['earn', 'give'].includes(parsed.payload.typ)) {
+      toast('Unsupported token', 'error');
+      return;
+    }
+    try {
+      const { res, body } = await adminFetch('/api/earn/scan', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token: parsed.token })
+      });
+      if (!res.ok) {
+        const msg = (body && body.error) || (typeof body === 'string' ? body : 'Scan failed');
+        throw new Error(msg);
+      }
+      const data = body && typeof body === 'object' ? body : {};
+      const amount = data.amount ?? '??';
+      const user = data.userId || 'unknown user';
+      toast(`Credited ${amount} to ${user}`);
     } catch (err) {
-      toast(err.message || 'Redeem failed', 'error');
+      toast(err.message || 'Scan failed', 'error');
     }
   },
-}); // <-- important: comma after onToken AND this call closer
-
-
-  setupScanner({
-    buttonId: 'btnEarnCamera',
-    videoId: 'earnVideo',
-    canvasId: 'earnCanvas',
-    statusId: 'earnScanStatus',
-    onToken: async (raw) => {
-      const parsed = parseTokenFromScan(raw);
-      if (!parsed || !['earn', 'give'].includes(parsed.payload.typ)) {
-        toast('Unsupported token', 'error');
-        return;
-      }
-      try {
-        const res = await adminFetch('/api/earn/scan', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ token: parsed.token })
-        });
-        const data = await res.json();
-        if (!res.ok) throw new Error(data.error || 'Scan failed');
-        toast(`Credited ${data.amount} to ${data.userId}`);
-      } catch (err) {
-        toast(err.message || 'Scan failed', 'error');
-      }
-    }
+}); // must close the call
 
   // ===== Rewards =====
   function applyUrlToggle(show) {
@@ -437,14 +450,14 @@ setupScanner({
 
   async function updateReward(id, body) {
     try {
-      const res = await adminFetch(`/api/rewards/${id}`, {
+      const { res, body: respBody } = await adminFetch(`/api/rewards/${id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body)
       });
       if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(data.error || 'update failed');
+        const msg = (respBody && respBody.error) || (typeof respBody === 'string' ? respBody : 'update failed');
+        throw new Error(msg);
       }
       toast('Reward updated');
       loadRewards();
@@ -455,26 +468,37 @@ setupScanner({
 
   async function createReward() {
     const name = $('rewardName').value.trim();
-    const price = Number($('rewardCost').value);
+    const cost = $('rewardCost').value;
     const imageUrl = $('rewardImage').value.trim();
     const description = $('rewardDescription').value.trim();
-    if (!name || !Number.isFinite(price) || price <= 0) {
+    const costValue = Number(cost);
+    if (!name || !Number.isFinite(costValue) || costValue <= 0) {
       toast('Enter name and positive price', 'error');
       return;
     }
     try {
-      const res = await adminFetch('/api/rewards', {
+      const payload = { name, cost: costValue, imageUrl, description };
+      const { res, body } = await adminFetch('/api/rewards', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name, price, imageUrl, description })
+        body: JSON.stringify(payload),
       });
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.error || 'create failed');
-      toast('Reward added');
+      if (res.status === 401) {
+        toast('Admin key invalid. Use "Mamapapa" → Save, then retry.', 'error');
+        return;
+      }
+      if (!res.ok) {
+        const msg = (body && body.error) || (typeof body === 'string' ? body : 'Create failed');
+        toast(msg, 'error');
+        return;
+      }
+      $('rewardsStatus').textContent = '';
+      toast('Reward created');
       $('rewardName').value = '';
       $('rewardCost').value = '';
       $('rewardImage').value = '';
       $('rewardDescription').value = '';
+      reloadRewards?.();
       loadRewards();
     } catch (err) {
       toast(err.message || 'Create failed', 'error');
@@ -503,15 +527,18 @@ setupScanner({
     try {
       uploadStatus.textContent = 'Uploading...';
       const base64 = await fileToDataUrl(file);
-      const res = await adminFetch('/admin/upload-image64', {
+      const { res, body } = await adminFetch('/admin/upload-image64', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ image64: base64 })
       });
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.error || 'upload failed');
-      $('rewardImage').value = data.url;
-      uploadStatus.textContent = `Uploaded: ${data.url}`;
+      if (!res.ok) {
+        const msg = (body && body.error) || (typeof body === 'string' ? body : 'upload failed');
+        throw new Error(msg);
+      }
+      const data = body && typeof body === 'object' ? body : {};
+      $('rewardImage').value = data.url || '';
+      uploadStatus.textContent = data.url ? `Uploaded: ${data.url}` : 'Uploaded';
     } catch (err) {
       uploadStatus.textContent = 'Upload failed';
       toast(err.message || 'Upload failed', 'error');
@@ -589,13 +616,15 @@ setupScanner({
     const youtube_url = prompt('YouTube URL (optional)') || null;
     const sort_order = Number(prompt('Sort order (optional)', '0')) || 0;
     try {
-      const res = await adminFetch('/api/earn-templates', {
+      const { res, body } = await adminFetch('/api/earn-templates', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ title, points, description, youtube_url, sort_order })
       });
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.error || 'create failed');
+      if (!res.ok) {
+        const msg = (body && body.error) || (typeof body === 'string' ? body : 'create failed');
+        throw new Error(msg);
+      }
       toast('Template added');
       loadTemplates();
     } catch (err) {
@@ -613,13 +642,15 @@ setupScanner({
     const youtube_url = prompt('YouTube URL', tpl.youtube_url || '') || null;
     const sort_order = Number(prompt('Sort order', tpl.sort_order));
     try {
-      const res = await adminFetch(`/api/earn-templates/${tpl.id}`, {
+      const { res, body } = await adminFetch(`/api/earn-templates/${tpl.id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ title, points, description, youtube_url, sort_order })
       });
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.error || 'update failed');
+      if (!res.ok) {
+        const msg = (body && body.error) || (typeof body === 'string' ? body : 'update failed');
+        throw new Error(msg);
+      }
       toast('Template updated');
       loadTemplates();
     } catch (err) {
@@ -629,13 +660,15 @@ setupScanner({
 
   async function updateTemplate(id, body) {
     try {
-      const res = await adminFetch(`/api/earn-templates/${id}`, {
+      const { res, body: respBody } = await adminFetch(`/api/earn-templates/${id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body)
       });
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.error || 'update failed');
+      if (!res.ok) {
+        const msg = (respBody && respBody.error) || (typeof respBody === 'string' ? respBody : 'update failed');
+        throw new Error(msg);
+      }
       toast('Template saved');
       loadTemplates();
     } catch (err) {
@@ -646,10 +679,10 @@ setupScanner({
   async function deleteTemplate(id) {
     if (!confirm('Delete this template?')) return;
     try {
-      const res = await adminFetch(`/api/earn-templates/${id}`, { method: 'DELETE' });
+      const { res, body } = await adminFetch(`/api/earn-templates/${id}`, { method: 'DELETE' });
       if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(data.error || 'delete failed');
+        const msg = (body && body.error) || (typeof body === 'string' ? body : 'delete failed');
+        throw new Error(msg);
       }
       toast('Template deleted');
       loadTemplates();
@@ -675,14 +708,19 @@ setupScanner({
     const userId = $('quickUser').value.trim();
     if (!templateId || !userId) return toast('Select template and user', 'error');
     try {
-      const res = await adminFetch('/api/earn/quick', {
+      const { res, body } = await adminFetch('/api/earn/quick', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ templateId, userId })
       });
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.error || 'quick failed');
-      toast(`Awarded ${data.amount} to ${data.userId}`);
+      if (!res.ok) {
+        const msg = (body && body.error) || (typeof body === 'string' ? body : 'quick failed');
+        throw new Error(msg);
+      }
+      const data = body && typeof body === 'object' ? body : {};
+      const amount = data.amount ?? '??';
+      const user = data.userId || userId;
+      toast(`Awarded ${amount} to ${user}`);
       $('quickUser').value = '';
     } catch (err) {
       toast(err.message || 'Quick award failed', 'error');
@@ -732,9 +770,12 @@ setupScanner({
     try {
       const params = buildHistoryParams();
       const qs = new URLSearchParams(params).toString();
-      const res = await adminFetch(`/api/history?${qs}`);
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.error || 'history failed');
+      const { res, body } = await adminFetch(`/api/history?${qs}`);
+      if (!res.ok) {
+        const msg = (body && body.error) || (typeof body === 'string' ? body : 'history failed');
+        throw new Error(msg);
+      }
+      const data = body && typeof body === 'object' ? body : {};
       historyTable.innerHTML = '';
       for (const row of data.rows || []) {
         const tr = document.createElement('tr');
@@ -770,4 +811,5 @@ setupScanner({
   });
 
 })();
-  console.info('admin.js loaded ok');
+
+console.info('admin.js loaded ok');

--- a/server/public/child.html
+++ b/server/public/child.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>CryptoKids – Child</title>
-  <link rel="icon" href="data:,">
-  <link rel="manifest" href="/manifest.webmanifest?v=__BUILD__">
+  <!-- <link rel="icon" href="/favicon.ico"> -->
+  <!-- <link rel="manifest" href="/manifest.webmanifest?v=__BUILD__"> -->
   <meta name="theme-color" content="#ffffff">
   <style>
     :root {
@@ -102,73 +102,13 @@
       font-weight: 600;
       cursor: pointer;
     }
-    /* Rewards thumbnails */
-.reward-card .reward-thumb{
-  width:96px !important;
-  height:96px !important;
-  object-fit:cover;
-  aspect-ratio:1/1;
-  display:block;
-}
 
-</head>
-<body>
-  <!-- ck11 -->
-<section class="card">
-  <h2 style="margin-left:0">Scan Earn QR</h2>
-  <button id="btnScan" style="padding:8px 14px;border:1px solid #ddd;border-radius:8px;background:#fff">Start Camera</button>
-  <video id="vid" playsinline style="width:100%;max-width:420px;border-radius:12px;margin-top:10px;display:none"></video>
-  <canvas id="cv" style="display:none"></canvas>
-  <div id="scanMsg" class="help" style="min-height:18px;margin-top:8px"></div>
-</section>
-
-<script src="https://unpkg.com/jsqr"></script>
-<!-- add just below jsqr -->
-<script src="/qrcode.min.js"></script>
-<script>
-  (function () {
-    const btn = document.getElementById('btnScan');
-    const vid = document.getElementById('vid');
-    const cv  = document.getElementById('cv');
-    const ctx = cv.getContext('2d');
-    const msg = document.getElementById('scanMsg');
-    let stream = null, raf = 0, busy = false;
-
-    function say(s){ msg.textContent = s; }
-    function secureOk(){
-      if (location.protocol === 'https:' || location.hostname === 'localhost') return true;
-      return false;
-    }
-
-    async function start() {
-      if (!secureOk()) {
-        say('Camera requires HTTPS. Open the ngrok https://… URL.');
-        return;
-      }
-      if (!navigator.mediaDevices?.getUserMedia) {
-        say('Camera API not available in this browser.');
-        return;
-      }
-      try {
-        // Try back camera; fall back to any camera
-        const try1 = { video: { facingMode: { ideal: 'environment' } } };
-        const try2 = { video: true };
-
-        try { stream = await navigator.mediaDevices.getUserMedia(try1); }
-        catch { stream = await navigator.mediaDevices.getUserMedia(try2); }
-
-        vid.srcObject = stream;
-        vid.style.display = 'block';
-        await vid.play();
-        say('Point the camera at the QR code.');
-        tick();
-      } catch (e) {
-        const name = e && e.name || '';
-        if (name === 'NotAllowedError') say('Camera permission denied. Check site permissions in your browser settings.');
-        else if (name === 'NotFoundError') say('No camera found.');
-        else if (name === 'NotReadableError') say('Camera in use by another app.');
-        else say('Camera blocked or unavailable.');
-      }
+    .reward-thumb {
+      width: 96px !important;
+      height: 96px !important;
+      object-fit: cover;
+      aspect-ratio: 1/1;
+      display: block;
     }
 
     #historyList {
@@ -388,6 +328,6 @@
 
   <script src="https://unpkg.com/jsqr"></script>
   <script src="/qrcode.min.js?v=__BUILD__"></script>
-  <script src="/child.js?v=__BUILD__"></script>
+  <script defer src="child.js?v={{shortCommit}}"></script>
 </body>
 </html>

--- a/server/public/child.js
+++ b/server/public/child.js
@@ -298,14 +298,19 @@
       $('shopEmpty').style.display = 'block';
       return;
     }
-    for (const item of items) {
+    items.forEach((item, index) => {
       const canAfford = balance >= item.price;
       const row = document.createElement('div');
       row.className = 'shop-item';
       if (item.imageUrl) {
         const img = document.createElement('img');
+        img.className = 'reward-thumb';
         img.src = item.imageUrl;
         img.alt = '';
+        img.loading = 'lazy';
+        img.width = 96; img.height = 96;
+        img.style.objectFit = 'cover';
+        img.style.aspectRatio = '1 / 1';
         img.onerror = () => img.remove();
         row.appendChild(img);
       } else {
@@ -316,7 +321,20 @@
       }
 
       const info = document.createElement('div');
-      info.innerHTML = `<div class="price">${item.title}</div><div class="muted">${item.price} points</div><div class="muted">${item.description || ''}</div>`;
+      const title = document.createElement('div');
+      title.className = 'price';
+      title.textContent = `${index + 1}. ${item.title}`;
+      info.appendChild(title);
+
+      const price = document.createElement('div');
+      price.className = 'muted';
+      price.textContent = `${item.price} points`;
+      info.appendChild(price);
+
+      const description = document.createElement('div');
+      description.className = 'muted';
+      description.textContent = item.description || '';
+      info.appendChild(description);
       row.appendChild(info);
 
       const btn = document.createElement('button');
@@ -325,7 +343,7 @@
       if (canAfford) btn.addEventListener('click', () => createHold(item));
       row.appendChild(btn);
       list.appendChild(row);
-    }
+    });
   }
 
   async function createHold(item) {


### PR DESCRIPTION
## Summary
- set the admin key placeholder/default to Mamapapa and upgrade adminFetch to always include the key while parsing JSON or text responses
- harden reward creation to use the new helper with clear error messaging and refreshes, plus auto-prefill the Mamapapa key when none is saved
- square and number child reward cards so thumbnails stay 96×96 and titles show their position

## Testing
node --check server/public/admin.js
(no output)

## Deployment
- Ensure the Render ADMIN_KEY environment variable is set to Mamapapa

------
https://chatgpt.com/codex/tasks/task_e_68e1f582e8908324b93a7e9c065e9151