### PR TITLE
Fix balances schema migration

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -107,6 +107,17 @@ function ensureSchema() {
     );
   `);
 
+  const balanceCols = db.prepare(`PRAGMA table_info('balances')`).all();
+  const hasUpdatedAt = balanceCols.some(c => c.name === "updated_at");
+  if (!hasUpdatedAt) {
+    db.exec("ALTER TABLE balances ADD COLUMN updated_at INTEGER DEFAULT 0");
+  }
+  db.exec(`
+    UPDATE balances
+    SET updated_at = strftime('%s','now')
+    WHERE updated_at IS NULL OR updated_at = 0;
+  `);
+
   const ledgerCols = db.prepare(`PRAGMA table_info(ledger)`).all();
   const requiredLedgerCols = new Set([
     "id", "at", "userId", "action", "delta", "balance_after",


### PR DESCRIPTION
## Summary
- inspect the balances table schema during startup
- add the missing updated_at column to legacy databases and backfill timestamps

## Testing
- DB_PATH=data/legacy-test.db PORT=4100 node server/index.js & curl -s -D - -H 'Content-Type: application/json' -X POST -d '{"userId":"kid1","itemId":1}' http://127.0.0.1:4100/api/holds
- curl -s -D - -H 'Content-Type: application/json' -H 'x-admin-key: Mamapapa' -X POST -d '{"title":"Chore","points":10}' http://127.0.0.1:4100/api/earn-templates
- curl -s -D - -H 'Content-Type: application/json' -H 'x-admin-key: Mamapapa' -X POST -d '{"userId":"kid1","templateId":1}' http://127.0.0.1:4100/api/earn/quick

------
https://chatgpt.com/codex/tasks/task_e_68e32b39c8808324bd24c9e8bbd5e4c7