### PR TITLE
Include QR text in hold creation response

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -709,7 +709,8 @@ app.post("/api/holds", express.json(), (req, res) => {
     });
 
     const { token } = createToken("spend", { holdId: id, cost: reward.price });
-    res.status(201).json({ holdId: id, token });
+    const qrText = buildQrUrl(req, token);
+    res.status(201).json({ holdId: id, token, qrText });
   } catch (e) {
     console.error("create hold", e);
     res.status(500).json({ error: "create hold failed" });


### PR DESCRIPTION
## Summary
- compute the QR URL string when a hold token is created
- return qrText with the hold response so the child page can render the QR code

## Testing
- browser_container.run_playwright_script (child hold QR verification)


------
https://chatgpt.com/codex/tasks/task_e_68e32c0c6e188324964ae7473d06657a