### PR TITLE
Add random ID fallback when UUID API unavailable

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -98,6 +98,13 @@ function normId(value) {
 const db = new Database(DB_PATH);
 db.pragma("journal_mode = WAL");
 
+function randomId() {
+  if (typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return crypto.randomBytes(16).toString("hex");
+}
+
 function ensureSchema() {
   db.exec(`
     CREATE TABLE IF NOT EXISTS balances (
@@ -350,7 +357,7 @@ function createToken(typ, data, ttl = TOKEN_TTL_SEC) {
   const now = nowSec();
   const payload = {
     typ,
-    jti: crypto.randomUUID(),
+    jti: randomId(),
     iat: now,
     exp: now + Math.max(10, ttl),
     data
@@ -689,7 +696,7 @@ app.post("/api/holds", express.json(), (req, res) => {
     const reward = db.prepare("SELECT id, name, price, image_url FROM rewards WHERE id = ? AND active = 1").get(itemId);
     if (!reward) return res.status(404).json({ error: "reward not found" });
 
-    const id = crypto.randomUUID();
+    const id = randomId();
     const createdAt = Date.now();
     db.prepare(`
       INSERT INTO holds (id, userId, status, itemId, itemName, itemImage, quotedCost, createdAt)

--- a/server/utils/qr.js
+++ b/server/utils/qr.js
@@ -1,8 +1,15 @@
 // utils/qr.js (ESM)
 import crypto from 'node:crypto';
 
+function randomId() {
+  if (typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return crypto.randomBytes(16).toString('hex');
+}
+
 export function signQR(dataObj, key, ttlMs = 60_000) {
-  const jti = crypto.randomUUID();
+  const jti = randomId();
   const exp = Date.now() + ttlMs;
   const payload = { ...dataObj, jti, exp };        // e.g., {kind:'earn', user:'child:rio', amt:5, task:'brushteth'}
   const body = Buffer.from(JSON.stringify(payload)).toString('base64url');


### PR DESCRIPTION
## Summary
- add a helper for generating random IDs that falls back to random bytes when `crypto.randomUUID` is unavailable
- reuse the helper for token and hold ID creation as well as QR signing

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e343d5e698832487e74699a427b002