### PR TITLE
Add reward approval flow and child redemption history

### DIFF
--- a/server/public/child.html
+++ b/server/public/child.html
@@ -131,6 +131,71 @@
       padding-bottom: 0;
     }
 
+    .notice-box {
+      background: #eff6ff;
+      border: 1px solid rgba(37, 99, 235, 0.2);
+      border-radius: 14px;
+      padding: 16px;
+      display: grid;
+      gap: 6px;
+      font-size: 14px;
+    }
+
+    .notice-box.muted {
+      background: #f8fafc;
+      border-color: rgba(148, 163, 184, 0.3);
+      color: var(--muted);
+    }
+
+    .notice-title {
+      font-weight: 600;
+      font-size: 15px;
+      color: var(--fg);
+    }
+
+    .notice-meta {
+      color: var(--muted);
+      font-size: 13px;
+    }
+
+    #recentRedeems {
+      border: 1px solid var(--line);
+      border-radius: 14px;
+      background: #f8fafc;
+      padding: 16px;
+      display: none;
+      gap: 12px;
+    }
+
+    #recentRedeems.active {
+      display: grid;
+    }
+
+    .recent-row {
+      display: grid;
+      gap: 4px;
+      padding-bottom: 12px;
+      border-bottom: 1px dashed rgba(148, 163, 184, 0.4);
+    }
+
+    .recent-row:last-child {
+      border-bottom: none;
+      padding-bottom: 0;
+    }
+
+    .recent-name {
+      font-weight: 600;
+      font-size: 15px;
+    }
+
+    .recent-meta {
+      font-size: 13px;
+      color: var(--muted);
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
     .earn-list {
       display: grid;
       gap: 12px;
@@ -283,6 +348,7 @@
         <span id="summary" class="muted"></span>
       </div>
       <div id="balanceResult" class="muted"></div>
+      <div id="redeemNotice" class="notice-box muted">Enter your user ID to see recent redeemed rewards.</div>
       <div id="historyList"></div>
     </section>
 
@@ -310,10 +376,12 @@
       <h2>Rewards Menu</h2>
       <div class="row">
         <button id="btnLoadItems" class="primary" style="flex:0 0 auto;">Load Rewards</button>
+        <button id="btnRecentRedeems" type="button" style="flex:0 0 auto;">Recent Redeemed Rewards</button>
       </div>
       <div id="shopList"></div>
       <div id="shopEmpty" class="muted" style="display:none;">No rewards yet.</div>
       <div id="shopMsg" class="muted"></div>
+      <div id="recentRedeems"></div>
       <div id="shopQrBox"></div>
     </section>
   </main>

--- a/server/public/child.js
+++ b/server/public/child.js
@@ -1,6 +1,9 @@
 (() => {
   const $ = (id) => document.getElementById(id);
   const LS_FILTER = 'ck_child_filters';
+  const RECENT_REDEEM_LIMIT = 50;
+  const RECENT_REDEEM_DISPLAY = 8;
+  let lastRedeemEntry = null;
 
   function getUserId() {
     return $('childUserId').value.trim();
@@ -15,6 +18,150 @@
     } catch { return {}; }
   }
 
+  function formatDateTime(value) {
+    const num = Number(value);
+    if (!Number.isFinite(num)) return '';
+    const date = new Date(num);
+    if (Number.isNaN(date.getTime())) return '';
+    return date.toLocaleString();
+  }
+
+  function updateRedeemNotice(entry, { fallbackText } = {}) {
+    const box = $('redeemNotice');
+    if (!box) return;
+    box.innerHTML = '';
+    if (!entry) {
+      box.classList.add('muted');
+      box.textContent = fallbackText || 'No redeemed rewards yet.';
+      return;
+    }
+    box.classList.remove('muted');
+    const title = document.createElement('div');
+    title.className = 'notice-title';
+    title.textContent = entry.note || 'Reward redeemed';
+
+    const whenText = formatDateTime(entry.at);
+    const whenLine = document.createElement('div');
+    whenLine.className = 'notice-meta';
+    whenLine.textContent = whenText ? `Redeemed on ${whenText}` : 'Redeemed reward';
+
+    const detailParts = [];
+    const spent = Math.abs(Number(entry.delta) || 0);
+    if (spent) detailParts.push(`Spent ${spent} points`);
+    const balanceAfter = Number(entry.balance_after);
+    if (Number.isFinite(balanceAfter)) detailParts.push(`Remaining balance: ${balanceAfter} points`);
+
+    box.appendChild(title);
+    box.appendChild(whenLine);
+    if (detailParts.length) {
+      const detailLine = document.createElement('div');
+      detailLine.className = 'notice-meta';
+      detailLine.textContent = detailParts.join(' • ');
+      box.appendChild(detailLine);
+    }
+  }
+
+  function renderRecentRedeemList(items) {
+    const box = $('recentRedeems');
+    if (!box) return;
+    box.innerHTML = '';
+    box.classList.add('active');
+    if (!Array.isArray(items) || !items.length) {
+      const empty = document.createElement('div');
+      empty.className = 'muted';
+      empty.textContent = 'No redeemed rewards yet.';
+      box.appendChild(empty);
+      return;
+    }
+    items.slice(0, RECENT_REDEEM_DISPLAY).forEach((entry) => {
+      const row = document.createElement('div');
+      row.className = 'recent-row';
+      const name = document.createElement('div');
+      name.className = 'recent-name';
+      name.textContent = entry.note || 'Reward redeemed';
+      const meta = document.createElement('div');
+      meta.className = 'recent-meta';
+      const parts = [];
+      const when = formatDateTime(entry.at);
+      if (when) parts.push(when);
+      const spent = Math.abs(Number(entry.delta) || 0);
+      if (spent) parts.push(`Spent ${spent} points`);
+      const balanceAfter = Number(entry.balance_after);
+      if (Number.isFinite(balanceAfter)) parts.push(`Balance ${balanceAfter} points`);
+      if (!parts.length) parts.push('Reward redeemed');
+      meta.textContent = parts.join(' • ');
+      row.appendChild(name);
+      row.appendChild(meta);
+      box.appendChild(row);
+    });
+  }
+
+  async function fetchRedeemHistory(userId, limit = RECENT_REDEEM_LIMIT) {
+    const res = await fetch(`/api/history/user/${encodeURIComponent(userId)}?limit=${limit}`);
+    const data = await res.json();
+    if (!res.ok) {
+      throw new Error(data?.error ? String(data.error) : 'Unable to load redeemed rewards.');
+    }
+    const rows = Array.isArray(data?.rows) ? data.rows : [];
+    return rows.filter(row => row.action === 'spend_redeemed');
+  }
+
+  async function refreshRedeemNotice() {
+    const userId = getUserId();
+    if (!userId) {
+      lastRedeemEntry = null;
+      updateRedeemNotice(null, { fallbackText: 'Enter your user ID to see recent redeemed rewards.' });
+      return;
+    }
+    if (lastRedeemEntry) {
+      updateRedeemNotice(lastRedeemEntry);
+    } else {
+      updateRedeemNotice(null, { fallbackText: 'Checking for redeemed rewards...' });
+    }
+    try {
+      const redeems = await fetchRedeemHistory(userId, 20);
+      lastRedeemEntry = redeems[0] || null;
+      if (lastRedeemEntry) {
+        updateRedeemNotice(lastRedeemEntry);
+      } else {
+        updateRedeemNotice(null, { fallbackText: 'No redeemed rewards yet.' });
+      }
+    } catch (err) {
+      updateRedeemNotice(null, { fallbackText: err?.message || 'Unable to load redeemed rewards.' });
+    }
+  }
+
+  async function showRecentRedeems() {
+    const userId = getUserId();
+    if (!userId) {
+      alert('Enter user id');
+      return;
+    }
+    const box = $('recentRedeems');
+    if (box) {
+      box.classList.add('active');
+      box.innerHTML = '<div class="muted">Loading...</div>';
+    }
+    try {
+      const redeems = await fetchRedeemHistory(userId);
+      lastRedeemEntry = redeems[0] || null;
+      if (lastRedeemEntry) {
+        updateRedeemNotice(lastRedeemEntry);
+      } else {
+        updateRedeemNotice(null, { fallbackText: 'No redeemed rewards yet.' });
+      }
+      renderRecentRedeemList(redeems);
+    } catch (err) {
+      if (box) {
+        box.innerHTML = '';
+        const msg = document.createElement('div');
+        msg.className = 'muted';
+        msg.textContent = err?.message || 'Failed to load redeemed rewards.';
+        box.appendChild(msg);
+      }
+    }
+  }
+
   // ===== Balance & history =====
   async function checkBalance() {
     const userId = getUserId();
@@ -24,6 +171,7 @@
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || 'failed');
       $('balanceResult').textContent = `Balance: ${data.balance} points • Earned ${data.earned} • Spent ${data.spent}`;
+      refreshRedeemNotice();
     } catch (err) {
       $('balanceResult').textContent = err.message || 'Failed to load balance';
     }
@@ -40,7 +188,15 @@
       const res = await fetch(`/api/history/user/${encodeURIComponent(userId)}?limit=200`);
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || 'failed');
-      renderHistory(data.rows || [], filters);
+      const rows = Array.isArray(data.rows) ? data.rows : [];
+      renderHistory(rows, filters);
+      const latestRedeem = rows.find(row => row.action === 'spend_redeemed') || null;
+      lastRedeemEntry = latestRedeem;
+      if (latestRedeem) {
+        updateRedeemNotice(latestRedeem);
+      } else {
+        updateRedeemNotice(null, { fallbackText: 'No redeemed rewards yet.' });
+      }
     } catch (err) {
       list.innerHTML = `<div class="muted">${err.message || 'Failed to load history'}</div>`;
     }
@@ -300,6 +456,7 @@
   }
 
   document.getElementById('btnLoadItems')?.addEventListener('click', loadRewards);
+  $('btnRecentRedeems')?.addEventListener('click', showRecentRedeems);
 
   async function loadRewards(){
     const list = $('shopList');


### PR DESCRIPTION
## Summary
- add an approval workflow to the admin QR scan page so rewards can be reviewed and redeemed in place, including balance summaries
- surface redemption notices and a "Recent Redeemed Rewards" history button in the child dashboard with supporting styles
- update child-side scripting to fetch recent redemption activity and notify the user when rewards are approved

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3ff2703788324842854e575e67130