### PR TITLE
Add admin reward editing and expand child redeem history

### DIFF
--- a/server/public/child.html
+++ b/server/public/child.html
@@ -158,7 +158,7 @@
       font-size: 13px;
     }
 
-    #recentRedeems {
+    .redeem-history-box {
       border: 1px solid var(--line);
       border-radius: 14px;
       background: #f8fafc;
@@ -167,8 +167,13 @@
       gap: 12px;
     }
 
-    #recentRedeems.active {
+    .redeem-history-box.active {
       display: grid;
+    }
+
+    #fullRedeems {
+      max-height: 360px;
+      overflow: auto;
     }
 
     .recent-row {
@@ -376,12 +381,14 @@
       <h2>Rewards Menu</h2>
       <div class="row">
         <button id="btnLoadItems" class="primary" style="flex:0 0 auto;">Load Rewards</button>
-        <button id="btnRecentRedeems" type="button" style="flex:0 0 auto;">Recent Redeemed Rewards</button>
+        <button id="btnRecentRedeems" type="button" style="flex:0 0 auto;">Show Recent Redeemed</button>
+        <button id="btnFullRedeems" type="button" style="flex:0 0 auto;">Show Full Redeemed History</button>
       </div>
       <div id="shopList"></div>
       <div id="shopEmpty" class="muted" style="display:none;">No rewards yet.</div>
       <div id="shopMsg" class="muted"></div>
-      <div id="recentRedeems"></div>
+      <div id="recentRedeems" class="redeem-history-box"></div>
+      <div id="fullRedeems" class="redeem-history-box"></div>
       <div id="shopQrBox"></div>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- add inline editing flow and activation toggle for rewards in the admin menu
- show inactive reward state with a badge and refresh buttons on update
- update the child rewards page with show/hide controls, a full history list, and improved styling for redeemed rewards

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e40f229ec88324a542a09e1be4366a