### PR TITLE
Add admin member management and shared user selection

### DIFF
--- a/server/public/admin.html
+++ b/server/public/admin.html
@@ -404,6 +404,7 @@
 
     <nav aria-label="Section navigation">
       <ul class="jump-links">
+        <li><a href="#secMember">Member Management</a></li>
         <li><a href="#secIssue">Issue Points</a></li>
         <li><a href="#secHolds">Holding Rewards To Be Redeemed</a></li>
         <li><a href="#secRewards">Rewards Menu</a></li>
@@ -413,19 +414,81 @@
     </nav>
 
     <main>
-      <section class="card" id="secIssue">
+      <section class="card" id="secMember">
         <div class="flex-between">
-          <h2>Issue Points</h2>
+          <h2>Member Management</h2>
           <div class="row compact" style="gap:10px; justify-content:flex-end; flex-wrap:wrap;">
-            <button id="btnIssueGenerate" class="primary">Generate QR</button>
-            <button id="btnIssueBalance">Check Balance</button>
-            <button class="view-history" data-history-type="earn">View History</button>
+            <button id="btnMemberInfo">Member Info</button>
+            <button id="btnMemberBalance">Check Balance</button>
+            <button class="view-history" data-history-type="all" data-history-scope="member">View History</button>
           </div>
         </div>
         <div class="stack">
           <label>User ID
-            <input id="issueUserId" type="text" placeholder="e.g., leo">
+            <input id="memberUserId" type="text" placeholder="e.g., leo">
           </label>
+          <div id="memberInfoPanel" class="stack" style="border:1px solid var(--line); border-radius:12px; padding:12px; background:rgba(37,99,235,0.04);">
+            <div id="memberInfoDetails" class="muted">Enter a user ID and click Member Info to view details.</div>
+          </div>
+          <small class="muted" id="memberStatus"></small>
+        </div>
+        <div class="stack" style="border-top:1px solid var(--line); padding-top:16px;">
+          <h3 style="margin:0; font-size:18px;">Register New Member</h3>
+          <div class="row">
+            <label>User ID
+              <input id="memberRegisterId" type="text" placeholder="unique id">
+            </label>
+            <label>Name
+              <input id="memberRegisterName" type="text" placeholder="full name">
+            </label>
+          </div>
+          <div class="row">
+            <label>Date of Birth
+              <input id="memberRegisterDob" type="date">
+            </label>
+            <label>Sex
+              <input id="memberRegisterSex" type="text" placeholder="e.g., Female">
+            </label>
+          </div>
+          <div class="row compact" style="justify-content:flex-end;">
+            <button id="btnMemberRegister" class="primary">Register Member</button>
+          </div>
+        </div>
+        <div class="stack" style="border-top:1px solid var(--line); padding-top:16px;">
+          <div class="flex-between" style="flex-wrap:wrap; gap:12px;">
+            <h3 style="margin:0; font-size:18px;">Existing Members</h3>
+            <div class="row compact" style="gap:10px; flex-wrap:wrap;">
+              <label style="flex:1 1 180px;">
+                <span class="muted" style="font-size:12px; text-transform:uppercase; letter-spacing:0.08em;">Search</span>
+                <input id="memberSearch" type="text" placeholder="search id or name">
+              </label>
+              <button id="btnMemberReload">Reload</button>
+            </div>
+          </div>
+          <div style="overflow:auto;">
+            <table class="table" id="memberTable">
+              <thead>
+                <tr>
+                  <th>User ID</th>
+                  <th>Name</th>
+                  <th>DOB</th>
+                  <th>Sex</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+          <small class="muted" id="memberListStatus"></small>
+        </div>
+      </section>
+
+      <section class="card" id="secIssue">
+        <div class="flex-between">
+          <h2>Issue Points</h2>
+          <button id="btnIssueGenerate" class="primary">Generate QR</button>
+        </div>
+        <div class="stack">
           <div class="row">
             <label>Amount
               <input id="issueAmount" type="number" min="1" step="1" placeholder="points">
@@ -446,7 +509,7 @@
       <section class="card" id="secHolds">
         <div class="flex-between">
           <h2>Holding Rewards To Be Redeemed</h2>
-          <button class="view-history" data-history-type="spend">View History</button>
+          <button class="view-history" data-history-type="spend" data-history-scope="member">View History</button>
         </div>
         <div class="row" style="align-items:flex-end;">
           <label>Status

--- a/server/public/admin.js
+++ b/server/public/admin.js
@@ -81,6 +81,353 @@
     new QRCode(el, { text, width: 200, height: 200 });
   }
 
+  const memberIdInput = $('memberUserId');
+  const memberStatusEl = $('memberStatus');
+  const memberInfoDetails = $('memberInfoDetails');
+  const memberTableBody = $('memberTable')?.querySelector('tbody');
+  const memberListStatus = $('memberListStatus');
+  const memberSearchInput = $('memberSearch');
+
+  function getMemberIdInfo() {
+    const raw = (memberIdInput?.value || '').trim();
+    return { raw, normalized: raw.toLowerCase() };
+  }
+
+  function normalizeMemberInput() {
+    if (!memberIdInput) return getMemberIdInfo();
+    const info = getMemberIdInfo();
+    if (info.raw && info.raw !== info.normalized) {
+      memberIdInput.value = info.normalized;
+      return { raw: info.normalized, normalized: info.normalized };
+    }
+    return info;
+  }
+
+  function requireMemberId({ silent = false } = {}) {
+    const info = normalizeMemberInput();
+    if (!info.normalized) {
+      if (!silent) toast('Enter user id', 'error');
+      memberIdInput?.focus();
+      return null;
+    }
+    return info.normalized;
+  }
+
+  function setMemberStatus(message) {
+    if (memberStatusEl) memberStatusEl.textContent = message || '';
+  }
+
+  function setMemberInfoMessage(message) {
+    if (!memberInfoDetails) return;
+    memberInfoDetails.innerHTML = '';
+    const div = document.createElement('div');
+    div.className = 'muted';
+    div.textContent = message;
+    memberInfoDetails.appendChild(div);
+  }
+
+  function renderMemberInfo(member) {
+    if (!memberInfoDetails) return;
+    memberInfoDetails.innerHTML = '';
+    if (!member) {
+      setMemberInfoMessage('No member found.');
+      return;
+    }
+    const nameEl = document.createElement('div');
+    nameEl.style.fontWeight = '600';
+    nameEl.textContent = member.name || member.userId;
+    memberInfoDetails.appendChild(nameEl);
+
+    const idEl = document.createElement('div');
+    idEl.className = 'muted mono';
+    idEl.textContent = `ID: ${member.userId}`;
+    memberInfoDetails.appendChild(idEl);
+
+    const dobEl = document.createElement('div');
+    dobEl.className = 'muted';
+    dobEl.textContent = `DOB: ${member.dob || '—'}`;
+    memberInfoDetails.appendChild(dobEl);
+
+    const sexEl = document.createElement('div');
+    sexEl.className = 'muted';
+    sexEl.textContent = `Sex: ${member.sex || '—'}`;
+    memberInfoDetails.appendChild(sexEl);
+  }
+
+  function memberIdChanged() {
+    normalizeMemberInput();
+    setMemberStatus('');
+    setMemberInfoMessage('Enter a user ID and click Member Info to view details.');
+    loadHolds();
+  }
+
+  memberIdInput?.addEventListener('change', memberIdChanged);
+  memberIdInput?.addEventListener('blur', normalizeMemberInput);
+  memberIdInput?.addEventListener('keyup', (event) => {
+    if (event.key === 'Enter') memberIdChanged();
+  });
+
+  $('btnMemberInfo')?.addEventListener('click', async () => {
+    const userId = requireMemberId();
+    if (!userId) return;
+    setMemberStatus('');
+    setMemberInfoMessage('Loading member info...');
+    try {
+      const { res, body } = await adminFetch(`/api/members/${encodeURIComponent(userId)}`);
+      if (res.status === 401) {
+        toast(ADMIN_INVALID_MSG, 'error');
+        setMemberInfoMessage('Admin key invalid.');
+        return;
+      }
+      if (res.status === 404) {
+        setMemberInfoMessage(`No profile found for "${userId}".`);
+        return;
+      }
+      if (!res.ok) {
+        const msg = (body && body.error) || (typeof body === 'string' ? body : 'Failed to load member');
+        throw new Error(msg);
+      }
+      const member = body && typeof body === 'object' ? body : null;
+      renderMemberInfo(member);
+      if (member) setMemberStatus(`Loaded member ${member.userId}.`);
+    } catch (err) {
+      console.error(err);
+      setMemberInfoMessage(err.message || 'Failed to load member.');
+      toast(err.message || 'Failed to load member', 'error');
+    }
+  });
+
+  $('btnMemberBalance')?.addEventListener('click', async () => {
+    const userId = requireMemberId();
+    if (!userId) return;
+    setMemberStatus('Fetching balance...');
+    try {
+      const { res, body } = await adminFetch(`/balance/${encodeURIComponent(userId)}`);
+      if (!res.ok) {
+        const msg = (body && body.error) || (typeof body === 'string' ? body : 'Failed to fetch balance');
+        throw new Error(msg);
+      }
+      const data = body && typeof body === 'object' ? body : {};
+      const balance = Number.isFinite(Number(data.balance)) ? Number(data.balance) : data.balance;
+      setMemberStatus(`Balance: ${balance ?? 0} points.`);
+    } catch (err) {
+      console.error(err);
+      setMemberStatus(err.message || 'Failed to fetch balance.');
+      toast(err.message || 'Failed to fetch balance', 'error');
+    }
+  });
+
+  async function submitMemberRegistration() {
+    const idEl = $('memberRegisterId');
+    const nameEl = $('memberRegisterName');
+    const dobEl = $('memberRegisterDob');
+    const sexEl = $('memberRegisterSex');
+    const userId = (idEl?.value || '').trim().toLowerCase();
+    const name = (nameEl?.value || '').trim();
+    const dob = (dobEl?.value || '').trim();
+    const sex = (sexEl?.value || '').trim();
+    if (!userId || !name) {
+      toast('User ID and name required', 'error');
+      return;
+    }
+    setMemberStatus('Registering member...');
+    try {
+      const { res, body } = await adminFetch('/api/members', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId, name, dob: dob || undefined, sex: sex || undefined })
+      });
+      if (res.status === 401) {
+        toast(ADMIN_INVALID_MSG, 'error');
+        setMemberStatus('Admin key invalid.');
+        return;
+      }
+      if (res.status === 409) {
+        throw new Error('User ID already exists');
+      }
+      if (!res.ok) {
+        const msg = (body && body.error) || (typeof body === 'string' ? body : 'Failed to register');
+        throw new Error(msg);
+      }
+      toast('Member registered');
+      setMemberStatus(`Registered member ${userId}.`);
+      if (idEl) idEl.value = '';
+      if (nameEl) nameEl.value = '';
+      if (dobEl) dobEl.value = '';
+      if (sexEl) sexEl.value = '';
+      if (memberIdInput) {
+        memberIdInput.value = userId;
+        memberIdChanged();
+      }
+      await loadMembersList();
+    } catch (err) {
+      console.error(err);
+      setMemberStatus(err.message || 'Failed to register member.');
+      toast(err.message || 'Failed to register member', 'error');
+    }
+  }
+
+  $('btnMemberRegister')?.addEventListener('click', submitMemberRegistration);
+
+  async function editMember(member) {
+    if (!member) return;
+    const namePrompt = prompt('Member name', member.name || '');
+    if (namePrompt === null) return;
+    const name = namePrompt.trim();
+    if (!name) {
+      toast('Name required', 'error');
+      return;
+    }
+    const dobPrompt = prompt('Date of birth (YYYY-MM-DD)', member.dob || '');
+    if (dobPrompt === null) return;
+    const dob = dobPrompt.trim();
+    const sexPrompt = prompt('Sex', member.sex || '');
+    if (sexPrompt === null) return;
+    const sex = sexPrompt.trim();
+    try {
+      const { res, body } = await adminFetch(`/api/members/${encodeURIComponent(member.userId)}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, dob: dob || undefined, sex: sex || undefined })
+      });
+      if (res.status === 401) {
+        toast(ADMIN_INVALID_MSG, 'error');
+        return;
+      }
+      if (!res.ok) {
+        const msg = (body && body.error) || (typeof body === 'string' ? body : 'Failed to update member');
+        throw new Error(msg);
+      }
+      toast('Member updated');
+      await loadMembersList();
+      const updated = body && typeof body === 'object' ? body.member || body : null;
+      if (updated && memberIdInput?.value === updated.userId) {
+        renderMemberInfo(updated);
+      }
+    } catch (err) {
+      console.error(err);
+      toast(err.message || 'Failed to update member', 'error');
+    }
+  }
+
+  async function deleteMember(member) {
+    if (!member) return;
+    if (!confirm(`Delete member "${member.userId}"? This cannot be undone.`)) return;
+    try {
+      const { res, body } = await adminFetch(`/api/members/${encodeURIComponent(member.userId)}`, {
+        method: 'DELETE'
+      });
+      if (res.status === 401) {
+        toast(ADMIN_INVALID_MSG, 'error');
+        return;
+      }
+      if (res.status === 404) {
+        toast('Member already removed', 'error');
+        return;
+      }
+      if (!res.ok) {
+        const msg = (body && body.error) || (typeof body === 'string' ? body : 'Failed to delete member');
+        throw new Error(msg);
+      }
+      toast('Member deleted');
+      if (memberIdInput?.value === member.userId) {
+        memberIdInput.value = '';
+        memberIdChanged();
+      }
+      await loadMembersList();
+    } catch (err) {
+      console.error(err);
+      toast(err.message || 'Failed to delete member', 'error');
+    }
+  }
+
+  async function loadMembersList() {
+    if (!memberTableBody) return;
+    const search = (memberSearchInput?.value || '').trim().toLowerCase();
+    memberTableBody.innerHTML = '<tr><td colspan="5" class="muted">Loading...</td></tr>';
+    if (memberListStatus) memberListStatus.textContent = '';
+    try {
+      const qs = search ? `?search=${encodeURIComponent(search)}` : '';
+      const { res, body } = await adminFetch(`/api/members${qs}`);
+      if (res.status === 401) {
+        toast(ADMIN_INVALID_MSG, 'error');
+        memberTableBody.innerHTML = '<tr><td colspan="5" class="muted">Admin key invalid.</td></tr>';
+        if (memberListStatus) memberListStatus.textContent = 'Admin key invalid.';
+        return;
+      }
+      if (!res.ok) {
+        const msg = (body && body.error) || (typeof body === 'string' ? body : 'Failed to load members');
+        throw new Error(msg);
+      }
+      const rows = Array.isArray(body) ? body : [];
+      memberTableBody.innerHTML = '';
+      if (!rows.length) {
+        memberTableBody.innerHTML = '<tr><td colspan="5" class="muted">No members found.</td></tr>';
+        if (memberListStatus) memberListStatus.textContent = 'No members found.';
+        return;
+      }
+      for (const row of rows) {
+        const tr = document.createElement('tr');
+        const idCell = document.createElement('td');
+        idCell.textContent = row.userId;
+        tr.appendChild(idCell);
+        const nameCell = document.createElement('td');
+        nameCell.textContent = row.name || '';
+        tr.appendChild(nameCell);
+        const dobCell = document.createElement('td');
+        dobCell.textContent = row.dob || '';
+        tr.appendChild(dobCell);
+        const sexCell = document.createElement('td');
+        sexCell.textContent = row.sex || '';
+        tr.appendChild(sexCell);
+        const actions = document.createElement('td');
+        actions.style.display = 'flex';
+        actions.style.flexWrap = 'wrap';
+        actions.style.gap = '6px';
+        actions.style.alignItems = 'center';
+
+        const selectBtn = document.createElement('button');
+        selectBtn.textContent = 'Select';
+        selectBtn.addEventListener('click', () => {
+          if (memberIdInput) {
+            memberIdInput.value = row.userId;
+            memberIdChanged();
+          }
+        });
+        actions.appendChild(selectBtn);
+
+        const editBtn = document.createElement('button');
+        editBtn.textContent = 'Edit';
+        editBtn.addEventListener('click', () => editMember(row));
+        actions.appendChild(editBtn);
+
+        const deleteBtn = document.createElement('button');
+        deleteBtn.textContent = 'Delete';
+        deleteBtn.addEventListener('click', () => deleteMember(row));
+        actions.appendChild(deleteBtn);
+
+        tr.appendChild(actions);
+        memberTableBody.appendChild(tr);
+      }
+      if (memberListStatus) {
+        const count = rows.length;
+        memberListStatus.textContent = `Showing ${count} member${count === 1 ? '' : 's'}.`;
+      }
+    } catch (err) {
+      console.error(err);
+      memberTableBody.innerHTML = `<tr><td colspan="5" class="muted">${err.message || 'Failed to load members.'}</td></tr>`;
+      if (memberListStatus) memberListStatus.textContent = err.message || 'Failed to load members.';
+    }
+  }
+
+  $('btnMemberReload')?.addEventListener('click', loadMembersList);
+
+  let memberSearchTimer = null;
+  memberSearchInput?.addEventListener('input', () => {
+    clearTimeout(memberSearchTimer);
+    memberSearchTimer = setTimeout(loadMembersList, 250);
+  });
+
   function parseTokenFromScan(data) {
     try {
       if (!data) return null;
@@ -107,11 +454,12 @@
   }
 
   async function generateIssueQr() {
-    const userId = $('issueUserId').value.trim();
+    const userId = requireMemberId();
+    if (!userId) return;
     const amount = Number($('issueAmount').value);
     const note = $('issueNote').value.trim();
-    if (!userId || !Number.isFinite(amount) || amount <= 0) {
-      toast('Enter user and positive amount', 'error');
+    if (!Number.isFinite(amount) || amount <= 0) {
+      toast('Enter a positive amount', 'error');
       return;
     }
     $('issueStatus').textContent = 'Generating QR...';
@@ -143,23 +491,6 @@
   }
   $('btnIssueGenerate')?.addEventListener('click', generateIssueQr);
 
-  $('btnIssueBalance')?.addEventListener('click', async () => {
-    const userId = $('issueUserId').value.trim();
-    if (!userId) return toast('Enter user id', 'error');
-    try {
-      const { res, body } = await adminFetch(`/balance/${encodeURIComponent(userId)}`);
-      if (res.status === 401){ toast(ADMIN_INVALID_MSG, 'error'); return; }
-      if (!res.ok){
-        const msg = (body && body.error) || (typeof body === 'string' ? body : 'Failed');
-        throw new Error(msg);
-      }
-      const data = body && typeof body === 'object' ? body : {};
-      $('issueStatus').textContent = `Balance: ${data.balance} points`;
-    } catch (err) {
-      toast(err.message || 'Balance failed', 'error');
-    }
-  });
-
   $('btnIssueCopy')?.addEventListener('click', () => {
     const text = $('issueLink').value;
     if (!text) return toast('Nothing to copy', 'error');
@@ -170,12 +501,27 @@
   const holdsTable = $('holdsTable')?.querySelector('tbody');
   async function loadHolds() {
     if (!holdsTable) return;
-    const status = $('holdFilter').value;
-    $('holdsStatus').textContent = 'Loading...';
+    const status = $('holdFilter')?.value || 'pending';
+    const info = normalizeMemberInput();
+    const normalizedUser = info.normalized;
+    const displayUser = normalizedUser || info.raw;
     holdsTable.innerHTML = '';
+    if (!normalizedUser) {
+      const msg = 'Enter a user ID above to view holds.';
+      $('holdsStatus').textContent = msg;
+      const row = document.createElement('tr');
+      const cell = document.createElement('td');
+      cell.colSpan = 6;
+      cell.className = 'muted';
+      cell.textContent = msg;
+      row.appendChild(cell);
+      holdsTable.appendChild(row);
+      return;
+    }
+    $('holdsStatus').textContent = 'Loading...';
     try {
       const { res, body } = await adminFetch(`/api/holds?status=${encodeURIComponent(status)}`);
-      if (res.status === 401){
+      if (res.status === 401) {
         toast(ADMIN_INVALID_MSG, 'error');
         $('holdsStatus').textContent = 'Admin key invalid.';
         holdsTable.innerHTML = '<tr><td colspan="6" class="muted">Admin key invalid.</td></tr>';
@@ -186,13 +532,20 @@
         throw new Error(msg);
       }
       const rows = Array.isArray(body) ? body : [];
-      if (!rows.length) {
-        holdsTable.innerHTML = '<tr><td colspan="6" class="muted">No holds</td></tr>';
-        $('holdsStatus').textContent = '';
+      const filtered = rows.filter(row => String(row.userId || '').trim().toLowerCase() === normalizedUser);
+      if (!filtered.length) {
+        const row = document.createElement('tr');
+        const cell = document.createElement('td');
+        cell.colSpan = 6;
+        cell.className = 'muted';
+        cell.textContent = `No holds for "${displayUser}".`;
+        row.appendChild(cell);
+        holdsTable.appendChild(row);
+        $('holdsStatus').textContent = `No holds for "${displayUser}".`;
         return;
       }
       const frag = document.createDocumentFragment();
-      for (const row of rows) {
+      for (const row of filtered) {
         const tr = document.createElement('tr');
         tr.dataset.holdId = row.id;
         tr.innerHTML = `
@@ -215,7 +568,9 @@
         frag.appendChild(tr);
       }
       holdsTable.appendChild(frag);
-      $('holdsStatus').textContent = '';
+      const count = filtered.length;
+      const suffix = count === 1 ? '' : 's';
+      $('holdsStatus').textContent = `Showing ${count} hold${suffix} for "${displayUser}".`;
     } catch (err) {
       console.error(err);
       $('holdsStatus').textContent = err.message || 'Failed to load holds';
@@ -223,7 +578,10 @@
   }
   $('btnReloadHolds')?.addEventListener('click', loadHolds);
   $('holdFilter')?.addEventListener('change', loadHolds);
-  document.addEventListener('DOMContentLoaded', loadHolds);
+  document.addEventListener('DOMContentLoaded', () => {
+    loadMembersList();
+    loadHolds();
+  });
 
   async function cancelHold(id) {
     if (!confirm('Cancel this hold?')) return;
@@ -917,9 +1275,20 @@ setupScanner({
 
   document.querySelectorAll('.view-history').forEach(btn => {
     btn.addEventListener('click', () => {
+      const preset = {};
       const type = btn.dataset.historyType;
-      if (type === 'spend') openHistory({ type: 'spend' });
-      else openHistory({ type: 'earn' });
+      if (type && type !== 'all') {
+        preset.type = type;
+      }
+      const scope = btn.dataset.historyScope;
+      if (scope === 'member') {
+        const userId = requireMemberId();
+        if (!userId) return;
+        preset.userId = userId;
+      } else if (btn.dataset.historyUser) {
+        preset.userId = btn.dataset.historyUser;
+      }
+      openHistory(preset);
     });
   });
 


### PR DESCRIPTION
## Summary
- add a member management section that controls the shared user ID across issuing points and holding rewards, with register/edit/delete tools
- wire up frontend logic for balance, history, and member info while reusing the shared user selection for holds filtering
- extend the server with a members table plus CRUD endpoints to back the new admin tools

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4215139d083248cb6adb8683fe72f