### PR TITLE
Remove redundant hold user ID input

### DIFF
--- a/server/public/admin.html
+++ b/server/public/admin.html
@@ -520,9 +520,6 @@
               <option value="all">All</option>
             </select>
           </label>
-          <label>User ID
-            <input id="holdUserId" type="text" placeholder="enter user id">
-          </label>
           <button id="btnReloadHolds">Reload</button>
         </div>
         <div style="overflow:auto;">

--- a/server/public/admin.js
+++ b/server/public/admin.js
@@ -499,29 +499,15 @@
 
   // ===== Holds =====
   const holdsTable = $('holdsTable')?.querySelector('tbody');
-  const holdUserInput = $('holdUserId');
   async function loadHolds() {
     if (!holdsTable) return;
     const status = $('holdFilter')?.value || 'pending';
-    const rawUserId = holdUserInput?.value?.trim() || '';
-    const normalizedUser = rawUserId.toLowerCase();
+    const memberInfo = normalizeMemberInput() || {};
+    const rawUserId = (memberInfo.raw || '').trim();
+    const normalizedUser = (memberInfo.normalized || '').trim();
     holdsTable.innerHTML = '';
     if (!normalizedUser) {
-      const msg = 'Enter a user ID to view holds.';
-      $('holdsStatus').textContent = msg;
-      const row = document.createElement('tr');
-      const cell = document.createElement('td');
-      cell.colSpan = 6;
-      cell.className = 'muted';
-      cell.textContent = msg;
-      row.appendChild(cell);
-      holdsTable.appendChild(row);
-      return;
-    }
-    $('holdsStatus').textContent = 'Loading...';
-    holdsTable.innerHTML = '';
-    if (!normalizedUser) {
-      const msg = 'Enter a user ID above to view holds.';
+      const msg = 'Enter a user ID in Member Management to view holds.';
       $('holdsStatus').textContent = msg;
       const row = document.createElement('tr');
       const cell = document.createElement('td');
@@ -592,10 +578,6 @@
   }
   $('btnReloadHolds')?.addEventListener('click', loadHolds);
   $('holdFilter')?.addEventListener('change', loadHolds);
-  holdUserInput?.addEventListener('change', loadHolds);
-  holdUserInput?.addEventListener('keyup', (event) => {
-    if (event.key === 'Enter') loadHolds();
-  });
   document.addEventListener('DOMContentLoaded', loadHolds);
 
   async function cancelHold(id) {


### PR DESCRIPTION
## Summary
- remove the separate user ID field from the Holding Rewards section of the admin page
- reuse the member management user selection when loading holds and update helper text accordingly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e42c741318832493d3240c54fdabff