### PR TITLE
Update member management visibility and form controls

### DIFF
--- a/server/public/admin.html
+++ b/server/public/admin.html
@@ -432,29 +432,38 @@
           </div>
           <small class="muted" id="memberStatus"></small>
         </div>
-        <div class="stack" style="border-top:1px solid var(--line); padding-top:16px;">
-          <h3 style="margin:0; font-size:18px;">Register New Member</h3>
-          <div class="row">
-            <label>User ID
-              <input id="memberRegisterId" type="text" placeholder="unique id">
-            </label>
-            <label>Name
-              <input id="memberRegisterName" type="text" placeholder="full name">
-            </label>
-          </div>
-          <div class="row">
-            <label>Date of Birth
-              <input id="memberRegisterDob" type="date">
-            </label>
-            <label>Sex
-              <input id="memberRegisterSex" type="text" placeholder="e.g., Female">
-            </label>
-          </div>
-          <div class="row compact" style="justify-content:flex-end;">
-            <button id="btnMemberRegister" class="primary">Register Member</button>
+        <div class="stack" style="border-top:1px solid var(--line); padding-top:16px;" id="memberRegisterContainer">
+          <button type="button" id="toggleMemberRegister" aria-controls="memberRegisterFields" aria-expanded="false" style="display:flex; align-items:center; gap:8px; background:none; border:none; padding:0; font:inherit; font-size:18px; cursor:pointer;">
+            <span>Register New Member</span>
+            <span aria-hidden="true" id="memberRegisterToggleArrow">▼</span>
+          </button>
+          <div class="stack" id="memberRegisterFields" hidden>
+            <div class="row">
+              <label>User ID
+                <input id="memberRegisterId" type="text" placeholder="unique id">
+              </label>
+              <label>Name
+                <input id="memberRegisterName" type="text" placeholder="full name">
+              </label>
+            </div>
+            <div class="row">
+              <label>Date of Birth
+                <input id="memberRegisterDob" type="date">
+              </label>
+              <label>Sex
+                <select id="memberRegisterSex">
+                  <option value="">Select sex</option>
+                  <option value="Boy">Boy</option>
+                  <option value="Girl">Girl</option>
+                </select>
+              </label>
+            </div>
+            <div class="row compact" style="justify-content:flex-end;">
+              <button id="btnMemberRegister" class="primary">Register Member</button>
+            </div>
           </div>
         </div>
-        <div class="stack" style="border-top:1px solid var(--line); padding-top:16px;">
+        <div class="stack" style="border-top:1px solid var(--line); padding-top:16px;" id="memberListSection" hidden>
           <div class="flex-between" style="flex-wrap:wrap; gap:12px;">
             <h3 style="margin:0; font-size:18px;">Existing Members</h3>
             <div class="row compact" style="gap:10px; flex-wrap:wrap;">

--- a/server/public/admin.js
+++ b/server/public/admin.js
@@ -87,6 +87,10 @@
   const memberTableBody = $('memberTable')?.querySelector('tbody');
   const memberListStatus = $('memberListStatus');
   const memberSearchInput = $('memberSearch');
+  const memberListSection = $('memberListSection');
+  const memberRegisterFields = $('memberRegisterFields');
+  const memberRegisterToggle = $('toggleMemberRegister');
+  const memberRegisterToggleArrow = $('memberRegisterToggleArrow');
 
   function getMemberIdInfo() {
     const raw = (memberIdInput?.value || '').trim();
@@ -125,6 +129,19 @@
     div.textContent = message;
     memberInfoDetails.appendChild(div);
   }
+
+  function setMemberRegisterExpanded(expanded) {
+    if (memberRegisterFields) memberRegisterFields.hidden = !expanded;
+    if (memberRegisterToggleArrow) memberRegisterToggleArrow.textContent = expanded ? '▲' : '▼';
+    if (memberRegisterToggle) memberRegisterToggle.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+  }
+
+  setMemberRegisterExpanded(false);
+
+  memberRegisterToggle?.addEventListener('click', () => {
+    const nextExpanded = memberRegisterFields ? memberRegisterFields.hidden : true;
+    setMemberRegisterExpanded(nextExpanded);
+  });
 
   function renderMemberInfo(member) {
     if (!memberInfoDetails) return;
@@ -344,6 +361,13 @@
   async function loadMembersList() {
     if (!memberTableBody) return;
     const search = (memberSearchInput?.value || '').trim().toLowerCase();
+    if (!search) {
+      memberTableBody.innerHTML = '';
+      if (memberListStatus) memberListStatus.textContent = 'Search for a member to view results.';
+      if (memberListSection) memberListSection.hidden = true;
+      return;
+    }
+    if (memberListSection) memberListSection.hidden = false;
     memberTableBody.innerHTML = '<tr><td colspan="5" class="muted">Loading...</td></tr>';
     if (memberListStatus) memberListStatus.textContent = '';
     try {


### PR DESCRIPTION
## Summary
- hide the existing member table until a search term is provided and keep results focused on the query
- swap the member sex text input for a dropdown limited to Boy/Girl values
- collapse the register member form behind an arrow toggle for a cleaner default view

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e437051be08324815a179f5a7e8dc0