### PR TITLE
Restructure member management cards

### DIFF
--- a/server/public/admin.html
+++ b/server/public/admin.html
@@ -195,6 +195,54 @@
       gap: 12px;
     }
 
+    .collapsible {
+      gap: 12px;
+    }
+
+    .collapsible .collapsible-content {
+      display: none;
+      gap: 12px;
+    }
+
+    .collapsible[data-expanded="true"] .collapsible-content {
+      display: grid;
+    }
+
+    .collapsible-toggle {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      background: none;
+      border: none;
+      padding: 0;
+      font: inherit;
+      font-size: 18px;
+      cursor: pointer;
+      justify-content: space-between;
+      width: 100%;
+      text-align: left;
+    }
+
+    .collapsible-toggle .arrow {
+      display: inline-flex;
+    }
+
+    #secRegisterMember .collapsible {
+      gap: 0;
+    }
+
+    #secRegisterMember .collapsible-toggle {
+      font-size: 20px;
+      font-weight: 600;
+      padding: 4px 0;
+    }
+
+    #secRegisterMember .collapsible-content {
+      margin-top: 12px;
+      padding-top: 16px;
+      border-top: 1px solid var(--line);
+    }
+
     .drop {
       border: 2px dashed var(--line);
       border-radius: 14px;
@@ -405,6 +453,8 @@
     <nav aria-label="Section navigation">
       <ul class="jump-links">
         <li><a href="#secMember">Member Management</a></li>
+        <li><a href="#secRegisterMember">Register New Member</a></li>
+        <li><a href="#secMemberList">Existing Members</a></li>
         <li><a href="#secIssue">Issue Points</a></li>
         <li><a href="#secHolds">Holding Rewards To Be Redeemed</a></li>
         <li><a href="#secRewards">Rewards Menu</a></li>
@@ -432,31 +482,46 @@
           </div>
           <small class="muted" id="memberStatus"></small>
         </div>
-        <div class="stack" style="border-top:1px solid var(--line); padding-top:16px;">
-          <h3 style="margin:0; font-size:18px;">Register New Member</h3>
-          <div class="row">
-            <label>User ID
-              <input id="memberRegisterId" type="text" placeholder="unique id">
-            </label>
-            <label>Name
-              <input id="memberRegisterName" type="text" placeholder="full name">
-            </label>
-          </div>
-          <div class="row">
-            <label>Date of Birth
-              <input id="memberRegisterDob" type="date">
-            </label>
-            <label>Sex
-              <input id="memberRegisterSex" type="text" placeholder="e.g., Female">
-            </label>
-          </div>
-          <div class="row compact" style="justify-content:flex-end;">
-            <button id="btnMemberRegister" class="primary">Register Member</button>
+      </section>
+
+      <section class="card" id="secRegisterMember">
+        <div class="stack collapsible" id="memberRegisterContainer" data-expanded="false">
+          <button type="button" id="toggleMemberRegister" aria-controls="memberRegisterFields" aria-expanded="false" class="collapsible-toggle">
+            <span>Register New Member</span>
+            <span aria-hidden="true" id="memberRegisterToggleArrow" class="arrow">▾</span>
+          </button>
+          <div class="stack collapsible-content" id="memberRegisterFields" aria-hidden="true" hidden>
+            <div class="row">
+              <label>User ID
+                <input id="memberRegisterId" type="text" placeholder="unique id">
+              </label>
+              <label>Name
+                <input id="memberRegisterName" type="text" placeholder="full name">
+              </label>
+            </div>
+            <div class="row">
+              <label>Date of Birth
+                <input id="memberRegisterDob" type="date">
+              </label>
+              <label>Sex
+                <select id="memberRegisterSex">
+                  <option value="">Select sex</option>
+                  <option value="Boy">Boy</option>
+                  <option value="Girl">Girl</option>
+                </select>
+              </label>
+            </div>
+            <div class="row compact" style="justify-content:flex-end;">
+              <button id="btnMemberRegister" class="primary">Register Member</button>
+            </div>
           </div>
         </div>
-        <div class="stack" style="border-top:1px solid var(--line); padding-top:16px;">
+      </section>
+
+      <section class="card" id="secMemberList" hidden>
+        <div class="stack" id="memberListSection" hidden>
           <div class="flex-between" style="flex-wrap:wrap; gap:12px;">
-            <h3 style="margin:0; font-size:18px;">Existing Members</h3>
+            <h2 style="margin:0; font-size:20px;">Existing Members</h2>
             <div class="row compact" style="gap:10px; flex-wrap:wrap;">
               <label style="flex:1 1 180px;">
                 <span class="muted" style="font-size:12px; text-transform:uppercase; letter-spacing:0.08em;">Search</span>

--- a/server/public/admin.js
+++ b/server/public/admin.js
@@ -87,6 +87,20 @@
   const memberTableBody = $('memberTable')?.querySelector('tbody');
   const memberListStatus = $('memberListStatus');
   const memberSearchInput = $('memberSearch');
+  const memberListSection = $('memberListSection');
+  const memberListCard = $('secMemberList');
+  const memberRegisterContainer = $('memberRegisterContainer');
+  const memberRegisterFields = $('memberRegisterFields');
+  const memberRegisterToggle = $('toggleMemberRegister');
+  const memberRegisterToggleArrow = $('memberRegisterToggleArrow');
+
+  function setMemberRegisterControlsDisabled(disabled) {
+    if (!memberRegisterFields) return;
+    const fields = memberRegisterFields.querySelectorAll('input, select, textarea, button');
+    fields.forEach((field) => {
+      field.disabled = disabled;
+    });
+  }
 
   function getMemberIdInfo() {
     const raw = (memberIdInput?.value || '').trim();
@@ -125,6 +139,26 @@
     div.textContent = message;
     memberInfoDetails.appendChild(div);
   }
+
+  function setMemberRegisterExpanded(expanded) {
+    const isExpanded = !!expanded;
+    if (memberRegisterContainer) memberRegisterContainer.dataset.expanded = isExpanded ? 'true' : 'false';
+    if (memberRegisterToggle) memberRegisterToggle.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
+    if (memberRegisterToggleArrow) memberRegisterToggleArrow.textContent = isExpanded ? '▴' : '▾';
+    if (!memberRegisterFields) return;
+
+    memberRegisterFields.setAttribute('aria-hidden', isExpanded ? 'false' : 'true');
+    memberRegisterFields.style.display = isExpanded ? 'grid' : 'none';
+    memberRegisterFields.toggleAttribute('hidden', !isExpanded);
+    setMemberRegisterControlsDisabled(!isExpanded);
+  }
+
+  setMemberRegisterExpanded(false);
+
+  memberRegisterToggle?.addEventListener('click', () => {
+    const currentlyExpanded = memberRegisterContainer?.dataset.expanded === 'true';
+    setMemberRegisterExpanded(!currentlyExpanded);
+  });
 
   function renderMemberInfo(member) {
     if (!memberInfoDetails) return;
@@ -344,6 +378,15 @@
   async function loadMembersList() {
     if (!memberTableBody) return;
     const search = (memberSearchInput?.value || '').trim().toLowerCase();
+    if (!search) {
+      memberTableBody.innerHTML = '';
+      if (memberListStatus) memberListStatus.textContent = 'Search for a member to view results.';
+      if (memberListSection) memberListSection.hidden = true;
+      if (memberListCard) memberListCard.hidden = true;
+      return;
+    }
+    if (memberListSection) memberListSection.hidden = false;
+    if (memberListCard) memberListCard.hidden = false;
     memberTableBody.innerHTML = '<tr><td colspan="5" class="muted">Loading...</td></tr>';
     if (memberListStatus) memberListStatus.textContent = '';
     try {


### PR DESCRIPTION
## Summary
- split member management, registration, and existing member views into dedicated cards with updated jump links
- keep the register form collapsed by default with refreshed styling so it only appears when expanded
- hide the existing-member card until a search runs and sync the toggle logic with the new layout in admin.js

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e437051be08324815a179f5a7e8dc0