### PR TITLE
Refactor admin member sections layout

### DIFF
--- a/server/public/admin.html
+++ b/server/public/admin.html
@@ -454,6 +454,9 @@
           </div>
           <small class="muted" id="memberStatus"></small>
         </div>
+      </section>
+
+      <section class="card" id="secRegisterMember">
         <div class="stack" style="border-top:1px solid var(--line); padding-top:16px;" id="memberRegisterContainer">
           <button type="button" id="toggleMemberRegister" aria-controls="memberRegisterFields" aria-expanded="false" style="display:flex; align-items:center; gap:8px; background:none; border:none; padding:0; font:inherit; font-size:18px; cursor:pointer;">
             <span>Register New Member</span>
@@ -485,7 +488,10 @@
             </div>
           </div>
         </div>
-        <div class="stack" style="border-top:1px solid var(--line); padding-top:16px;" id="memberListSection" hidden>
+      </section>
+
+      <section class="card" id="secMemberList">
+        <div class="stack" style="border-top:1px solid var(--line); padding-top:16px;" id="memberListSection">
           <div class="flex-between" style="flex-wrap:wrap; gap:12px;">
             <h2 style="margin:0; font-size:20px;">Existing Members</h2>
             <div class="row compact" style="gap:10px; flex-wrap:wrap;">

--- a/server/public/admin.js
+++ b/server/public/admin.js
@@ -363,8 +363,8 @@
     const search = (memberSearchInput?.value || '').trim().toLowerCase();
     if (!search) {
       memberTableBody.innerHTML = '';
-      if (memberListStatus) memberListStatus.textContent = 'Search for a member to view results.';
-      if (memberListSection) memberListSection.hidden = true;
+      if (memberListStatus) memberListStatus.textContent = 'Type in the search box to list members.';
+      if (memberListSection) memberListSection.hidden = false;
       return;
     }
     if (memberListSection) memberListSection.hidden = false;


### PR DESCRIPTION
## Summary
- split the member register and member list content into standalone cards so the anchor links resolve
- ensure the existing members section stays visible even with an empty search

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e48d34b4988324b56bbf9613d91a9f