### PR TITLE
Fix lint errors in admin and child video helpers

### DIFF
--- a/server/public/admin.js
+++ b/server/public/admin.js
@@ -72,37 +72,43 @@
       const m = String(u).match(/([\w-]{11})/);
       return m ? m[1] : "";
     }
+  }
 
-    function waitForReady(oframe, timeout = 1800) {
-      return new Promise((resolve, reject) => {
-        let timer = null;
-        let settled = false;
+  function waitForReady(oframe, timeout = 1800) {
+    return new Promise((resolve, reject) => {
+      let timer = null;
+      let settled = false;
 
-        const finish = (fn, value) => {
-          if (settled) return;
-          settled = true;
-          if (timer) {
-            clearTimeout(timer);
-            timer = null;
-          }
-          window.removeEventListener("message", onMessage);
-          fn(value);
-        };
+      const finish = (fn, value) => {
+        if (settled) return;
+        settled = true;
+        if (timer) {
+          clearTimeout(timer);
+          timer = null;
+        }
+        window.removeEventListener("message", onMessage);
+        fn(value);
+      };
 
-        function onMessage(event) {
-          if (event.source !== oframe.contentWindow) return;
-          let payload = event.data;
-          if (typeof payload === "string") {
-            try {
-              payload = JSON.parse(payload);
-            } catch (error) {
-              // ignore non-JSON payloads
-            }
-          }
-          if (payload && payload.event === "onReady") {
-            finish(resolve);
+      function onMessage(event) {
+        if (event.source !== oframe.contentWindow) return;
+        let payload = event.data;
+        if (typeof payload === "string") {
+          try {
+            payload = JSON.parse(payload);
+          } catch (error) {
+            // ignore non-JSON payloads
           }
         }
+        if (payload && payload.event === "onReady") {
+          finish(resolve);
+        }
+      }
+
+      window.addEventListener("message", onMessage);
+      timer = setTimeout(() => finish(reject, new Error("timeout")), timeout);
+    });
+  }
 
   (function setupVideoModal() {
     const modal = document.getElementById("videoModal");

--- a/server/public/child.js
+++ b/server/public/child.js
@@ -8,39 +8,38 @@
   let recentRedeemsVisible = false;
   let fullRedeemsVisible = false;
 
-  function extractYouTubeId(u) {
-    if (!u) return "";
-    try {
-      // Allow raw IDs
-      if (/^[\w-]{11}$/.test(u)) return u;
+    function extractYouTubeId(u) {
+      if (!u) return "";
+      try {
+        // Allow raw IDs
+        if (/^[\w-]{11}$/.test(u)) return u;
 
-      const x = new URL(u);
-      // youtu.be/<id>
-      if (x.hostname.includes("youtu.be")) {
-        return (x.pathname.split("/")[1] || "").split("?")[0].split("&")[0];
+        const x = new URL(u);
+        // youtu.be/<id>
+        if (x.hostname.includes("youtu.be")) {
+          return (x.pathname.split("/")[1] || "").split("?")[0].split("&")[0];
+        }
+        // youtube.com/watch?v=<id>
+        const v = x.searchParams.get("v");
+        if (v) return v.split("&")[0];
+
+        // youtube.com/shorts/<id>
+        const mShorts = x.pathname.match(/\/shorts\/([\w-]{11})/);
+        if (mShorts) return mShorts[1];
+
+        // youtube.com/embed/<id>
+        const mEmbed = x.pathname.match(/\/embed\/([\w-]{11})/);
+        if (mEmbed) return mEmbed[1];
+
+        // Last resort: first 11-char token
+        const m = u.match(/([\w-]{11})/);
+        if (m) return m[1];
+      } catch {
+        // ignore parsing errors and fall back to loose matching below
       }
-      // youtube.com/watch?v=<id>
-      const v = x.searchParams.get("v");
-      if (v) return v.split("&")[0];
-
-      // youtube.com/shorts/<id>
-      const mShorts = x.pathname.match(/\/shorts\/([\w-]{11})/);
-      if (mShorts) return mShorts[1];
-
-      // youtube.com/embed/<id>
-      const mEmbed = x.pathname.match(/\/embed\/([\w-]{11})/);
-      if (mEmbed) return mEmbed[1];
-
-      // Last resort: first 11-char token
-      const m = u.match(/([\w-]{11})/);
-      return m ? m[1] : "";
-    } catch {
-      const m = String(u).match(/([\w-]{11})/);
-      return m ? m[1] : "";
+      const fallback = String(u).match(/([\w-]{11})/);
+      return fallback ? fallback[1] : "";
     }
-    const fallback = String(u).match(/([\w-]{11})/);
-    return fallback ? fallback[1] : "";
-  }
 
   function getYouTubeThumbnail(url) {
     const id = extractYouTubeId(url);


### PR DESCRIPTION
## Summary
- restore the admin video helper closure and add an isolated `waitForReady` helper to avoid syntax errors during linting
- clean up the child video helper's YouTube ID extraction so the fallback branch is reachable while handling bad URLs gracefully

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6681ec0bc8324bc827a0bb668d5ba